### PR TITLE
Fix optional arg example

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Usage
 
 Start the server:
 
-    omega [-port <port>] [-pass <password>]
+    omega [--port <port>] [--pass <password>]
 
 `<port>` - Where the server listens for connections. Defaults to 1337.
 


### PR DESCRIPTION
Optimist doesn't seem to parse the args if you only use one dash
