### PR TITLE
Added support for multiple issue IDs using commas

### DIFF
--- a/public/js/ProjectView.js
+++ b/public/js/ProjectView.js
@@ -94,6 +94,19 @@ function ($, _, ko, timeago, tooltips, util, Issue, Notifier, UserManager, Messa
 		var match = string.match(/(\d+)(?:\s+(.+))?/);
 		return match ? match[argToReturn] : null;
 	}
+
+	function eachID(id, this_, funcToCall, args) {
+		if (typeof args == 'undefined'){ 
+		       args = [];
+		}
+		var ids = id.split(',');
+		args.unshift(parseInt(id[0], 10));
+
+		_.each(ids, function(i){
+			args[0] = parseInt(i, 10);
+			funcToCall.apply(this_, args);
+		});
+	}
 	
 	ProjectView.prototype.notifyOfBadCommand = function () {
 		this.alert(flavour.badCommand() + ' Try /help.');
@@ -169,46 +182,63 @@ function ($, _, ko, timeago, tooltips, util, Issue, Notifier, UserManager, Messa
 				case 'close':
 				case 'resolve':
 				case 'done':
-					id = parseInt(rest, 10);
-					requireArgument(id);
-					this.issueManager.closeIssue(id);
+					id = rest.split(' ')[0];
+                                        requireArgument(id);
+					eachID(id, this.issueManager, this.issueManager.closeIssue);
+
 					break;
 				case 'reopen':
-					id = parseInt(rest, 10);
+					id = rest.split(' ')[0];
 					requireArgument(id);
-					this.issueManager.updateIssue(id, { closed: false });
+					eachID(id, this.issueManager, this.issueManager.updateIssue, [{ closed: false }]);
+
 					break;
 				case 'unassign':
-					id = parseInt(rest, 10);
-					requireArgument(id);
-					this.issueManager.assignIssue(id, 'nobody');
+					id = rest.split(' ')[0];
+				        requireArgument(id);
+					eachID(id, this.issueManager, this.issueManager.assignIssue, ['nobody']);
+
 					break;
 				case 'assign':
 				case '@':
-					id = parseInt(getArgument(rest, 1), 10);
-					var assignee = getArgument(rest, 2);
+					//The first argument are the ids
+					id = rest.split(' ')[0];
+					//The rest are asignee
+					var assignee = rest.split(' ');
+					assignee.shift()
+					assignee = assignee.join(' ');
+
 					requireArgument(id);
-					this.issueManager.assignIssue(id, assignee);
+					eachID(id, this.issueManager, this.issueManager.assignIssue, [assignee]);
+
 					break;
 				case 'tag':
-					id = parseInt(getArgument(rest, 1), 10);
-					var tag = getArgument(rest, 2);
+					//The first argument are the ids
+					id = rest.split(' ')[0];
+					//The rest are tag
+					var tag = rest.split(' ');
+					tag.shift()
+					tag = tag.join(' ');
+
 					requireArgument(id, tag);
-					this.issueManager.tagIssue(id, tag);
+					eachID(id, this.issueManager, this.issueManager.tagIssue, [tag]);
+
 					break;
 				case 'untag':
-					id = parseInt(getArgument(rest, 1), 10);
+					id = rest.split(' ')[0];
 					requireArgument(id);
-					this.issueManager.untagIssue(id);
+					eachID(id, this.issueManager, this.issueManager.untagIssue);
+
 					break;
 				case 'critical':
 				case 'urgent':
 				case '!':
 				case '*':
 				case 'star':
-					id = parseInt(getArgument(rest, 1), 10);
+					id = rest.split(' ')[0];
 					requireArgument(id);
-					this.issueManager.prioritizeIssue(id);
+					eachID(id, this.issueManager, this.issueManager.prioritizeIssue);
+
 					break;
 				case 'edit':
 				case 'update':

--- a/public/js/ProjectView.js
+++ b/public/js/ProjectView.js
@@ -103,7 +103,8 @@ function ($, _, ko, timeago, tooltips, util, Issue, Notifier, UserManager, Messa
 		args.unshift(parseInt(id[0], 10));
 
 		_.each(ids, function(i){
-			args[0] = parseInt(i, 10);
+            args[0] = parseInt(i, 10);
+            requireArgument(args[0]);
 			funcToCall.apply(this_, args);
 		});
 	}
@@ -182,42 +183,47 @@ function ($, _, ko, timeago, tooltips, util, Issue, Notifier, UserManager, Messa
 				case 'close':
 				case 'resolve':
 				case 'done':
+                    requireArgument(rest);
 					id = rest.split(' ')[0];
-                                        requireArgument(id);
 					eachID(id, this.issueManager, this.issueManager.closeIssue);
 
 					break;
 				case 'reopen':
+                    requireArgument(rest);
 					id = rest.split(' ')[0];
-					requireArgument(id);
 					eachID(id, this.issueManager, this.issueManager.updateIssue, [{ closed: false }]);
 
 					break;
 				case 'unassign':
+                    requireArgument(rest);
 					id = rest.split(' ')[0];
-				        requireArgument(id);
 					eachID(id, this.issueManager, this.issueManager.assignIssue, ['nobody']);
 
 					break;
 				case 'assign':
 				case '@':
+                    requireArgument(rest);
 					//The first argument are the ids
 					id = rest.split(' ')[0];
 					//The rest are asignee
 					var assignee = rest.split(' ');
-					assignee.shift()
+					assignee.shift();
 					assignee = assignee.join(' ');
 
-					requireArgument(id);
+                    if (assignee === ''){
+                        assignee = undefined;
+                    }
+
 					eachID(id, this.issueManager, this.issueManager.assignIssue, [assignee]);
 
 					break;
 				case 'tag':
+                    requireArgument(rest); //check if no args
 					//The first argument are the ids
 					id = rest.split(' ')[0];
 					//The rest are tag
 					var tag = rest.split(' ');
-					tag.shift()
+					tag.shift();
 					tag = tag.join(' ');
 
 					requireArgument(id, tag);
@@ -225,8 +231,8 @@ function ($, _, ko, timeago, tooltips, util, Issue, Notifier, UserManager, Messa
 
 					break;
 				case 'untag':
+                    requireArgument(rest);
 					id = rest.split(' ')[0];
-					requireArgument(id);
 					eachID(id, this.issueManager, this.issueManager.untagIssue);
 
 					break;
@@ -235,8 +241,8 @@ function ($, _, ko, timeago, tooltips, util, Issue, Notifier, UserManager, Messa
 				case '!':
 				case '*':
 				case 'star':
+                    requireArgument(rest);
 					id = rest.split(' ')[0];
-					requireArgument(id);
 					eachID(id, this.issueManager, this.issueManager.prioritizeIssue);
 
 					break;


### PR DESCRIPTION
The `getArgument` didn't quite work as I needed it to. What I expected for it was that it would split the arguments string like I did and just return me what I wanted. I tried to stick to the original syntax and comment the parts that needed it and if you want I will put more comments but as a lot of the code didn't have comments I didn't want to overcomment something as simple as this. Another great thing to add would be - and \* where - would be from to (1-5) and \* would be a wildcard like it always is.
